### PR TITLE
Fix 'static assertion failed comparison object must be invocable as const' error

### DIFF
--- a/.github/workflows/cpp-build.yml
+++ b/.github/workflows/cpp-build.yml
@@ -28,7 +28,7 @@ jobs:
         conda info
         conda list
     - name: Install BioPerl >=1.7.2
-      run: conda install "perl-bioperl>=1.7.2" "gxx_linux-64 ==7.3.0"
+      run: conda install "perl-bioperl>=1.7.2" "gxx_linux-64 ==7.3.0" "perl-list-moreutils"
     - name: g++ version
       run: g++ --version
     - name: configure

--- a/c/Application.cpp
+++ b/c/Application.cpp
@@ -6,7 +6,7 @@
 // overwrites stuff between "" in the line below magic
 // see the Makefile in the project root
 // magic (do not modify): iMMmwyWGTTGeJ6TYQg2myA
-const string Application::version = "2.5.0.1"; // do not modify
+const string Application::version = "2.5.0.2"; // do not modify
 
 const int Application :: I_oligo_size_min = 12;
 const int Application :: I_oligo_size_max = 100;

--- a/c/Match.cpp
+++ b/c/Match.cpp
@@ -137,7 +137,7 @@ void Match::onSequence( const string& na, const Cover<Position>& amb, Alignment&
 
 // 	(2) build the minimum set of sequences
 	struct ClusterSizeCompare{
-		bool operator() ( const Cluster& c1, const Cluster& c2 ) {
+		bool operator() ( const Cluster& c1, const Cluster& c2 ) const {
 			const size_t s1 = clusters.at( c1 ).size();
 			const size_t s2 = clusters.at( c2 ).size();
 

--- a/c/aodp.help.cpp
+++ b/c/aodp.help.cpp
@@ -2,7 +2,7 @@
 
 const string Application::_help =
 "NAME\n"
-"     aodp - Automated Oligonucleotide Design Pipeline version \"2.5.0.1\"\n"
+"     aodp - Automated Oligonucleotide Design Pipeline version \"2.5.0.2\"\n"
 "\n"
 "SYNOPSIS\n"
 "    aodp [*options*] *output* *fasta-sequence-file...*\n"

--- a/man/Makefile
+++ b/man/Makefile
@@ -8,7 +8,7 @@
 # see the Makefile in the project root
 # magic line below (do not modify)
 # iMMmwyWGTTGeJ6TYQg2myA
-VERSION= "2.5.0.1"
+VERSION= "2.5.0.2"
 
 PERL_DIR= ../pl
 POD_DIR= pod

--- a/man/pod/aodp
+++ b/man/pod/aodp
@@ -9,7 +9,7 @@ see the Makefile in the project root
 magic line below (do not modify)
 
 L<|iMMmwyWGTTGeJ6TYQg2myA>
-aodp - Automated Oligonucleotide Design Pipeline version "2.5.0.1"
+aodp - Automated Oligonucleotide Design Pipeline version "2.5.0.2"
 
 =head1 SYNOPSIS
 

--- a/pl/clado
+++ b/pl/clado
@@ -54,7 +54,7 @@ see the Makefile in the project root
 magic line below (do not modify)
 
 L<|iMMmwyWGTTGeJ6TYQg2myA>
-Cladogram generator (clado) version "2.5.0.1"
+Cladogram generator (clado) version "2.5.0.2"
 
 =head1 SYNOPSIS
 

--- a/pl/clus
+++ b/pl/clus
@@ -292,7 +292,7 @@ see the Makefile in the project root
 magic line below (do not modify)
 
 L<|iMMmwyWGTTGeJ6TYQg2myA>
-Cluster oligo signature analyzer (C<clus>) version "2.5.0.1"
+Cluster oligo signature analyzer (C<clus>) version "2.5.0.2"
 
 =head1 SYNOPSIS
 

--- a/pl/tax2nwk
+++ b/pl/tax2nwk
@@ -89,7 +89,7 @@ see the Makefile in the project root
 magic line below (do not modify)
 
 L<|iMMmwyWGTTGeJ6TYQg2myA>
-Taxonomy to Newick convertor (C<tax2nwk>) version "2.5.0.1"
+Taxonomy to Newick convertor (C<tax2nwk>) version "2.5.0.2"
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This PR fixes #1 by adding `const` to `operator` method in `Match.cpp` `ClusterSizeCompare` struct.